### PR TITLE
Redirect after: custom messages and paths

### DIFF
--- a/lib/auxiliary_rails/concerns/resourceable.rb
+++ b/lib/auxiliary_rails/concerns/resourceable.rb
@@ -189,13 +189,19 @@ module AuxiliaryRails
       # redirects
 
       def redirect_after_create
-        if flash[:notice].blank?
-          flash[:notice] = t('create.notice',
-            resource_name: resource_class.model_name.human,
-            scope: i18n_scope)
-        end
+        flash[:notice] ||= redirect_after_create_message
 
-        redirect_to resource_path(resource)
+        redirect_to redirect_after_create_path
+      end
+
+      def redirect_after_create_message
+        t('create.notice',
+          resource_name: resource_class.model_name.human,
+          scope: i18n_scope)
+      end
+
+      def redirect_after_create_path
+        resource_path(resource)
       end
 
       def redirect_after_update
@@ -215,13 +221,19 @@ module AuxiliaryRails
       end
 
       def redirect_after_destroy
-        if flash[:notice].blank?
-          flash[:notice] = t('destroy.notice',
-            resource_name: resource_class.model_name.human,
-            scope: i18n_scope)
-        end
+        flash[:notice] ||= redirect_after_destroy_message
 
-        redirect_to collection_path
+        redirect_to redirect_after_destroy_path
+      end
+
+      def redirect_after_destroy_message
+        t('destroy.notice',
+          resource_name: resource_class.model_name.human,
+          scope: i18n_scope)
+      end
+
+      def redirect_after_destroy_path
+        collection_path
       end
 
       # system

--- a/lib/auxiliary_rails/concerns/resourceable.rb
+++ b/lib/auxiliary_rails/concerns/resourceable.rb
@@ -199,13 +199,19 @@ module AuxiliaryRails
       end
 
       def redirect_after_update
-        if flash[:notice].blank?
-          flash[:notice] = t('update.notice',
-            resource_name: resource_class.model_name.human,
-            scope: i18n_scope)
-        end
+        flash[:notice] ||= redirect_after_update_message
 
-        redirect_to resource_path(resource)
+        redirect_to redirect_after_update_path
+      end
+
+      def redirect_after_update_message
+        t('update.notice',
+          resource_name: resource_class.model_name.human,
+          scope: i18n_scope)
+      end
+
+      def redirect_after_update_path
+        resource_path(resource)
       end
 
       def redirect_after_destroy


### PR DESCRIPTION
In the `redirect_after_*` methods messages and paths can be overridden.

Example case: This is helpful when the user cannot access the resource's `show` action, and `redirect_after_update_path` can be set to the `edit` path. The message can be overridden as well.